### PR TITLE
[MM-29569] add https support and use config.json for service configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ debug
 Session.vim
 .netrwhist
 *~
+
+# Ignore config.json
+config/config.json

--- a/cmd/bifrost/main.go
+++ b/cmd/bifrost/main.go
@@ -14,13 +14,19 @@ import (
 )
 
 func main() {
-	var port string
-	flag.StringVar(&port, "port", "8087", "Port number for the http server.")
+	var configFile string
+	flag.StringVar(&configFile, "config", "config/config.json", "Configuration file for the Bifrost service.")
 	flag.Parse()
 
-	s := server.New(port)
+	config, err := server.ParseConfig(configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not parse config file: %s\n", err)
+		os.Exit(1)
+	}
+
+	s := server.New(config)
 	go func() {
-		fmt.Printf("listening on port %s\n", port)
+		fmt.Printf("listening on port %s\n", config.ServiceSettings.Port)
 		if err := s.Start(); err != nil {
 			fmt.Fprintf(os.Stderr, "could not start the server: %s\n", err)
 			os.Exit(1)

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,0 +1,17 @@
+{
+    "ServiceSettings": {
+        "Port": "8087",
+        "TLSCertFile": "",
+        "TLSKeyFile": "",
+        "MaxConnsPerHost": 500,
+        "ResponseHeaderTimeout": 30
+    },
+    "S3Settings": {
+        "AccessKeyId": "",
+        "SecretAccessKey": "",
+        "Bucket": "",
+        "Region": "us-east-1",
+        "Endpoint": "s3.dualstack.us-east-1.amazonaws.com",
+        "Scheme": "https"
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mattermost/bifrost
 
 go 1.15
+
+require github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mattermost/bifrost
 
 go 1.15
 
-require github.com/kelseyhightower/envconfig v1.4.0
+require (
+	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+// Config is the configration for a bifrost server.
+type Config struct {
+	ServiceSettings *ServiceSettings  `split_words:"true"`
+	S3Settings      *AmazonS3Settings `split_words:"true"`
+}
+
+// ServiceSettings is the configuration related to the web server.
+type ServiceSettings struct {
+	Port                  string
+	TLSCertFile           string `split_words:"true"`
+	TLSKeyFile            string `split_words:"true"`
+	MaxConnsPerHost       int    `split_words:"true"`
+	ResponseHeaderTimeout int    `split_words:"true"`
+}
+
+// AmazonS3Settings is the configuration related to the Amazon S3.
+type AmazonS3Settings struct {
+	AccessKeyID     string `split_words:"true"`
+	SecretAccessKey string `split_words:"true"`
+	Bucket          string
+	Region          string
+	Endpoint        string
+	Scheme          string
+}
+
+// ParseConfig reads the config file and returns a new *Config,
+// This method overrides values in the file if there is any environment
+// variables corresponding to a specific setting.
+func ParseConfig(path string) (*Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %w", err)
+	}
+	defer file.Close()
+
+	var cfg Config
+	err = json.NewDecoder(file).Decode(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode file: %w", err)
+	}
+
+	if err = envconfig.Process("bifrost", &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// Config is the configration for a bifrost server.
+// Config is the configuration for a bifrost server.
 type Config struct {
 	ServiceSettings ServiceSettings  `split_words:"true"`
 	S3Settings      AmazonS3Settings `split_words:"true"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -13,8 +13,8 @@ import (
 
 // Config is the configration for a bifrost server.
 type Config struct {
-	ServiceSettings *ServiceSettings  `split_words:"true"`
-	S3Settings      *AmazonS3Settings `split_words:"true"`
+	ServiceSettings ServiceSettings  `split_words:"true"`
+	S3Settings      AmazonS3Settings `split_words:"true"`
 }
 
 // ServiceSettings is the configuration related to the web server.
@@ -39,22 +39,22 @@ type AmazonS3Settings struct {
 // ParseConfig reads the config file and returns a new *Config,
 // This method overrides values in the file if there is any environment
 // variables corresponding to a specific setting.
-func ParseConfig(path string) (*Config, error) {
+func ParseConfig(path string) (Config, error) {
+	var cfg Config
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("could not open file: %w", err)
+		return cfg, fmt.Errorf("could not open file: %w", err)
 	}
 	defer file.Close()
 
-	var cfg Config
 	err = json.NewDecoder(file).Decode(&cfg)
 	if err != nil {
-		return nil, fmt.Errorf("could not decode file: %w", err)
+		return cfg, fmt.Errorf("could not decode file: %w", err)
 	}
 
 	if err = envconfig.Process("bifrost", &cfg); err != nil {
-		return nil, err
+		return cfg, err
 	}
 
-	return &cfg, nil
+	return cfg, nil
 }

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -43,7 +43,7 @@ func TestParseConfig(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("should be able to read a valid json file", func(t *testing.T) {
+	t.Run("should be able to read a valid json file and override with env. var.", func(t *testing.T) {
 		f := filepath.Join(dir, "valid.json")
 		err = ioutil.WriteFile(f, []byte(`{
 			"ServiceSettings": {

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package server
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig(t *testing.T) {
+	dir, err := ioutil.TempDir("", "bifrost-test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	t.Run("empty input should fail", func(t *testing.T) {
+		_, err = ParseConfig("")
+		require.Error(t, err)
+	})
+
+	t.Run("non existing file should fail", func(t *testing.T) {
+		_, err = ParseConfig(filepath.Join(dir, "nonexistent.json"))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json format should fail", func(t *testing.T) {
+		f := filepath.Join(dir, "empty.json")
+		err = ioutil.WriteFile(f, []byte("\n"), 0644)
+		_, err = ParseConfig(f)
+		require.Error(t, err)
+	})
+
+	t.Run("should be able to read a valid json file", func(t *testing.T) {
+		f := filepath.Join(dir, "valid.json")
+		err = ioutil.WriteFile(f, []byte("{}\n"), 0644)
+		_, err := ParseConfig(f)
+		require.NoError(t, err)
+	})
+}

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -39,7 +39,24 @@ func TestParseConfig(t *testing.T) {
 	t.Run("should be able to read a valid json file", func(t *testing.T) {
 		f := filepath.Join(dir, "valid.json")
 		err = ioutil.WriteFile(f, []byte("{}\n"), 0644)
-		_, err := ParseConfig(f)
+		_, err = ParseConfig(f)
 		require.NoError(t, err)
+	})
+
+	t.Run("should be able to read a valid json file", func(t *testing.T) {
+		f := filepath.Join(dir, "valid.json")
+		err = ioutil.WriteFile(f, []byte(`{
+			"ServiceSettings": {
+				"Port": "8087",
+				"TLSCertFile": ""
+			}
+		}
+		`), 0644)
+		os.Setenv("BIFROST_SERVICE_SETTINGS_PORT", "8099")
+		os.Setenv("BIFROST_SERVICE_SETTINGS_TLS_CERT_FILE", "/home/test/file.cert")
+		cfg, err := ParseConfig(f)
+		require.NoError(t, err)
+		require.Equal(t, cfg.ServiceSettings.Port, "8099")
+		require.Equal(t, cfg.ServiceSettings.TLSCertFile, "/home/test/file.cert")
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net"
 	"net/http"
@@ -19,26 +20,49 @@ var (
 
 // Server contains all the necessary information to run Bifrost
 type Server struct {
-	srv *http.Server
+	certFile string
+	keyFile  string
+	srv      *http.Server
 }
 
 // New creates a new Bifrost server
-func New(port string) *Server {
-	s := &Server{
-		srv: &http.Server{
-			Addr:         net.JoinHostPort("0.0.0.0", port),
-			ReadTimeout:  60 * time.Second,
-			WriteTimeout: 60 * time.Second,
-			IdleTimeout:  30 * time.Second,
+func New(cfg *Config) *Server {
+	server := &http.Server{
+		Addr:         net.JoinHostPort("0.0.0.0", cfg.ServiceSettings.Port),
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
+
+	server.TLSConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 		},
 	}
 
+	s := &Server{
+		certFile: cfg.ServiceSettings.TLSCertFile,
+		keyFile:  cfg.ServiceSettings.TLSKeyFile,
+		srv:      server,
+	}
 	return s
 }
 
 // Start starts the server
 func (s *Server) Start() error {
-	err := s.srv.ListenAndServe()
+	var err error
+	if s.certFile != "" && s.keyFile != "" {
+		err = s.srv.ListenAndServeTLS(s.certFile, s.keyFile)
+	} else {
+		err = s.srv.ListenAndServe()
+	}
+
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,7 @@ var (
 
 // Server contains all the necessary information to run Bifrost
 type Server struct {
-	cfg *Config
+	cfg Config
 	srv *http.Server
 }
 
@@ -31,18 +31,17 @@ func New(cfg Config) *Server {
 		ReadTimeout:  60 * time.Second,
 		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  30 * time.Second,
-	}
-
-	server.TLSConfig = &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		CurvePreferences: []tls.CurveID{
-			tls.CurveP256,
+		TLSConfig: &tls.Config{
+			MinVersion:               tls.VersionTLS12,
+			PreferServerCipherSuites: true,
+			CurvePreferences: []tls.CurveID{
+				tls.CurveP256,
+			},
 		},
 	}
 
 	s := &Server{
-		cfg: &cfg,
+		cfg: cfg,
 		srv: server,
 	}
 	return s


### PR DESCRIPTION
#### Summary
Add `https` support and use `config/config.json` for service configuration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29569

