### PR TITLE
[MM-29719] add health endpoint

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,6 +1,7 @@
 {
     "ServiceSettings": {
         "Host": "localhost:8087",
+        "HealthHost": "localhost:8099",
         "TLSCertFile": "",
         "TLSKeyFile": "",
         "MaxConnsPerHost": 500,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/bifrost
 go 1.15
 
 require (
+	github.com/gorilla/mux v1.7.4
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattermost/mattermost-server/v5 v5.28.0
 	github.com/minio/minio-go/v7 v7.0.5

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,7 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -21,6 +21,7 @@ type Config struct {
 // ServiceSettings is the configuration related to the web server.
 type ServiceSettings struct {
 	Host                  string
+	HealthHost            string `split_words:"true"`
 	TLSCertFile           string `split_words:"true"`
 	TLSKeyFile            string `split_words:"true"`
 	MaxConnsPerHost       int    `split_words:"true"`

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -19,7 +19,7 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	err := json.NewEncoder(w).Encode(healthResponse{CommitHash: CommitHash, BuildDate: BuildDate})
 	if err != nil {
 		s.logger.Error("failed to write health response", mlog.Err(err))
-		w.WriteHeader(http.StatusInternalServerError)
+		http.Error(w, "failed to write health response", http.StatusInternalServerError)
 		return
 	}
 }

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+)
+
+type healthResponse struct {
+	CommitHash string `json:"commit_hash"`
+	BuildDate  string `json:"build_date"`
+}
+
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	err := json.NewEncoder(w).Encode(healthResponse{CommitHash: CommitHash, BuildDate: BuildDate})
+	if err != nil {
+		s.logger.Error("failed to write health response", mlog.Err(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthHandler(t *testing.T) {
+	s := &Server{
+		logger: mlog.NewTestingLogger(t, os.Stderr),
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(s.healthHandler))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	defer res.Body.Close()
+
+	err = json.NewDecoder(res.Body).Decode(&healthResponse{})
+	require.NoError(t, err)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,8 +11,10 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
@@ -27,6 +29,7 @@ var (
 type Server struct {
 	cfg       Config
 	srv       *http.Server
+	healthSrv *http.Server
 	logger    *mlog.Logger
 	client    *http.Client
 	getHostFn func(bucket, endPoint string) string
@@ -69,9 +72,19 @@ func New(cfg Config) *Server {
 		},
 	}
 
+	healthMux := mux.NewRouter()
+	healthServer := &http.Server{
+		Addr:         cfg.ServiceSettings.HealthHost,
+		Handler:      healthMux,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
+
 	s := &Server{
-		srv:    server,
-		client: client,
+		srv:       server,
+		healthSrv: healthServer,
+		client:    client,
 		logger: mlog.NewLogger(&mlog.LoggerConfiguration{
 			ConsoleJson:   cfg.LogSettings.ConsoleJSON,
 			ConsoleLevel:  strings.ToLower(cfg.LogSettings.ConsoleLevel),
@@ -87,31 +100,54 @@ func New(cfg Config) *Server {
 
 	s.getHostFn = s.getHost
 	s.srv.Handler = s.withRecovery(s.handler())
+	healthMux.HandleFunc("/health", s.healthHandler).Methods("GET")
 
 	return s
 }
 
 // Start starts the server
 func (s *Server) Start() error {
-	s.logger.Info("server started", mlog.String("host", s.cfg.ServiceSettings.Host))
-	var err error
-	if s.cfg.ServiceSettings.TLSCertFile != "" && s.cfg.ServiceSettings.TLSKeyFile != "" {
-		err = s.srv.ListenAndServeTLS(s.cfg.ServiceSettings.TLSCertFile, s.cfg.ServiceSettings.TLSKeyFile)
-	} else {
-		err = s.srv.ListenAndServe()
-	}
+	var wg sync.WaitGroup
 
-	if errors.Is(err, http.ErrServerClosed) {
-		return nil
+	errChan := make(chan error, 2)
+	wg.Add(1)
+	go func() {
+		s.logger.Info("server started", mlog.String("host", s.cfg.ServiceSettings.Host))
+		var err error
+		if s.cfg.ServiceSettings.TLSCertFile != "" && s.cfg.ServiceSettings.TLSKeyFile != "" {
+			err = s.srv.ListenAndServeTLS(s.cfg.ServiceSettings.TLSCertFile, s.cfg.ServiceSettings.TLSKeyFile)
+		} else {
+			err = s.srv.ListenAndServe()
+		}
+		errChan <- err
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		errChan <- s.healthSrv.ListenAndServe()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		if !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 // Stop stops the server
 func (s *Server) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	return s.srv.Shutdown(ctx)
+
+	if err := s.srv.Shutdown(ctx); err != nil {
+		return err
+	}
+	return s.healthSrv.Shutdown(ctx)
 }
 
 func (s *Server) withRecovery(next http.Handler) http.Handler {


### PR DESCRIPTION

#### Summary
Adds a health endpoint so that K8s can ping this endpoint to know the state of the server. It returns the commit hash and build date info as a `json` object to confirm that everything is okay.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29719

