### PR TITLE
Change from error to warning for response writing

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -61,7 +61,7 @@ func (s *Server) handler() http.HandlerFunc {
 
 		_, err = io.Copy(w, resp.Body)
 		if err != nil {
-			s.logger.Error("failed to copy response body", mlog.Err(err))
+			s.logger.Warn("failed to copy response body", mlog.Err(err))
 		}
 	}
 }
@@ -89,6 +89,6 @@ func (s *Server) writeError(w http.ResponseWriter, sourceErr error) {
 	w.WriteHeader(http.StatusInternalServerError)
 	_, err = w.Write(buf.Bytes())
 	if err != nil {
-		s.logger.Error("failed to write error response", mlog.Err(err))
+		s.logger.Warn("failed to write error response", mlog.Err(err))
 	}
 }


### PR DESCRIPTION
This frequently happens on poor network connectivity
or if the client cancels a video/audio stream. Let's change to warning
to not make it an actionable error.
