### PR TITLE
Remove path and size from metrics

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -36,21 +36,19 @@ func newMetrics() *metrics {
 			Name:      "requests_duration",
 			Help:      "Duration of the http requests.",
 		},
-		[]string{"path", "method", "status_code", "installation_id", "size"},
+		[]string{"method", "status_code", "installation_id"},
 	)
 	m.registry.MustRegister(m.requestsDuration)
 
 	return m
 }
 
-func (m *metrics) observeRequest(path, method, installationID string, statusCode int, size int64, duration float64) {
+func (m *metrics) observeRequest(method, installationID string, statusCode int, duration float64) {
 	m.requestsDuration.With(
 		prometheus.Labels{
-			"path":            path,
 			"method":          method,
 			"status_code":     strconv.Itoa(statusCode),
 			"installation_id": installationID,
-			"size":            strconv.FormatInt(size, 10),
 		},
 	).Observe(duration)
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -31,25 +31,21 @@ func TestMetrics(t *testing.T) {
 		m := &prometheusModels.Metric{}
 		data, err := metrics.requestsDuration.GetMetricWith(
 			prometheus.Labels{
-				"path":            "path",
 				"method":          "method",
 				"status_code":     "200",
 				"installation_id": "",
-				"size":            "",
 			})
 		require.NoError(t, err)
 		require.NoError(t, data.(prometheus.Histogram).Write(m))
 		require.Equal(t, uint64(0), m.Histogram.GetSampleCount())
 		require.Equal(t, 0.0, m.Histogram.GetSampleSum())
 
-		metrics.observeRequest("path/to/file.jpg", "GET", "random_id", 200, 1, 1.0)
+		metrics.observeRequest("GET", "random_id", 200, 1.0)
 		data, err = metrics.requestsDuration.GetMetricWith(
 			prometheus.Labels{
-				"path":            "path/to/file.jpg",
 				"method":          "GET",
 				"installation_id": "random_id",
 				"status_code":     "200",
-				"size":            "1",
 			})
 		require.NoError(t, err)
 		require.NoError(t, data.(prometheus.Histogram).Write(m))


### PR DESCRIPTION
It was found by the SRE team that bifrost was showing very high
cardinality for its metrics. On deeper investigation we found that since path and size
are added as labels, basically every single request to any file is causing a new label
to be aded.

So we are cleaning them up. Not sure why I added those in the first place, but they are
better tracked via loggin.