### PR TITLE
fix: empty image tag on cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,13 +19,13 @@ jobs:
       uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v3.2.0
 
     - name: cd/set-tag-pr
-      if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+      if: (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'push') && github.event.workflow_run.conclusion == 'success'
       run: |
         echo "INCOMING_PR_SHA=${{ github.event.workflow_run.head_sha }}"
         echo "IMAGE_TAG=${INCOMING_PR_SHA:0:7}" >> $GITHUB_ENV
 
     - name: cd/set-tag-push
-      if: github.ref_type == 'tag' || env.IMAGE_TAG == ''
+      if: github.ref_type == 'tag'
       run: echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
 
     - name: cd/setup-buildx

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
         echo "IMAGE_TAG=${INCOMING_PR_SHA:0:7}" >> $GITHUB_ENV
 
     - name: cd/set-tag-push
-      if: github.ref_type == 'tag'
+      if: github.ref_type == 'tag' || env.IMAGE_TAG == ''
       run: echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
 
     - name: cd/setup-buildx


### PR DESCRIPTION
#### Summary
Fixes having an empty `IMAGE_TAG` on the Github Action CD workflow

https://github.com/mattermost/bifrost/actions/runs/5388236840/jobs/9780611663
