### PR TITLE
Apply s3utils.EncodePath to match signature gen

### DIFF
--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -142,6 +142,77 @@ func TestHandler(t *testing.T) {
 		// Verify response headers
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode, "unexpected status code")
 	})
+
+	t.Run("escaped characters", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// We test that the bucket name is stripped.
+			assert.Equal(t, "/foo bar+", r.URL.Path)
+
+			// We verify the unescaped path
+			assert.Equal(t, "/foo%20bar%2B", r.RequestURI)
+
+			now := time.Now()
+
+			// Validate request headers
+			authHeader := r.Header.Get("Authorization")
+			date := r.Header.Get("X-Amz-Date")
+
+			assert.True(t, strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256"), "unexpected prefix for Authorization header: %s", authHeader)
+			assert.True(t, strings.HasPrefix(date, now.Format("20060102")), "unexpected prefix for X-Amz-Date header: %s", date)
+
+			matches := regCred.FindStringSubmatch(authHeader)
+			require.Len(t, matches, 3, "unexpected number of matches")
+			assert.Equal(t, cfg.S3Settings.AccessKeyID, matches[1], "unexpected access key")
+			assert.Equal(t, now.Format("20060102"), matches[2], "unexpected date value")
+
+			matches = regSign.FindStringSubmatch(authHeader)
+			require.Len(t, matches, 2, "unexpected number of matches")
+
+			w.Header().Set("Content-Type", "application/xml")
+			w.Header().Set("Date", now.Format(time.RFC1123))
+			w.Header().Set("Last-Modified", now.Format(time.RFC1123))
+			w.Header().Set("Server", "Asgard")
+			w.Header().Set("X-Amz-Bucket-Region", cfg.S3Settings.Region)
+			w.Header().Set("X-Amz-Id-2", "id")
+			w.Header().Set("X-Amz-Request-Id", "reqId")
+
+			fmt.Fprintln(w, "Welcome to the realm eternal")
+		}))
+		defer ts.Close()
+
+		dummyGetHost := func(bucket, endPoint string) string {
+			return strings.TrimPrefix(ts.URL, "http://")
+		}
+
+		s := &Server{
+			logger:    mlog.NewTestingLogger(t, os.Stderr),
+			cfg:       cfg,
+			getHostFn: dummyGetHost,
+			client:    http.DefaultClient,
+			creds: credentials.NewStatic(cfg.S3Settings.AccessKeyID,
+				cfg.S3Settings.SecretAccessKey, "", credentials.SignatureV4),
+			metrics: newMetrics(),
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com/"+cfg.S3Settings.Bucket+"/foo%20bar%2B", nil)
+		w := httptest.NewRecorder()
+
+		s.handler()(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+
+		// Verify response headers
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code")
+		assert.Equal(t, "application/xml", resp.Header.Get("Content-Type"), "unexpected content type")
+		assert.Equal(t, "Asgard", resp.Header.Get("Server"), "unexpected server")
+		assert.Equal(t, cfg.S3Settings.Region, resp.Header.Get("X-Amz-Bucket-Region"), "unexpected region")
+		assert.Equal(t, "id", resp.Header.Get("X-Amz-Id-2"), "unexpected id")
+		assert.Equal(t, "reqId", resp.Header.Get("X-Amz-Request-Id"), "unexpected request id")
+		assert.NotEmpty(t, resp.Header.Get("Date"), "empty date")
+		assert.NotEmpty(t, resp.Header.Get("Last-Modified"), "empty last-modified")
+	})
 }
 
 func TestWriteError(t *testing.T) {


### PR DESCRIPTION
#### Summary
Don't rely on `net.URL` to escape, as it correctly applies RFC 3986 and doesn't bother escaping a `+` in the URL. Instead, apply `s3utils.EncodePath` to the URL, matching the way the minio signature package builds the canonical URL and avoiding a signature mismatch.

This change should be accompanied by reverting https://github.com/mattermost/mattermost/pull/23849, but we'll still need to keep the code to try the "newer" path until we can migrate the files incorrectly named during the deployment window.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-51753