### PR TITLE
Add request validation

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -9,7 +9,8 @@
         "ReadTimeoutSecs": 30,
         "WriteTimeoutSecs": 30,
         "IdleTimeoutSecs": 30,
-        "RequestValidation": false
+        "RequestValidation": false,
+        "RequestValidationExpectedNameSuffix": "svc.cluster.local."
     },
     "S3Settings": {
         "AccessKeyId": "",

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -9,7 +9,7 @@
         "ReadTimeoutSecs": 30,
         "WriteTimeoutSecs": 30,
         "IdleTimeoutSecs": 30,
-        "ReverseAddressLookupValidation": false
+        "RequestValidation": false
     },
     "S3Settings": {
         "AccessKeyId": "",

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -8,7 +8,8 @@
         "ResponseHeaderTimeoutSecs": 30,
         "ReadTimeoutSecs": 30,
         "WriteTimeoutSecs": 30,
-        "IdleTimeoutSecs": 30
+        "IdleTimeoutSecs": 30,
+        "ReverseAddressLookupValidation": false
     },
     "S3Settings": {
         "AccessKeyId": "",

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattermost/mattermost-server/v5 v5.28.0
 	github.com/minio/minio-go/v7 v7.0.58
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
 	github.com/stretchr/testify v1.8.2
@@ -31,7 +32,6 @@ require (
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -987,6 +988,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -178,7 +178,6 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -988,7 +987,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -20,15 +20,16 @@ type Config struct {
 
 // ServiceSettings is the configuration related to the web server.
 type ServiceSettings struct {
-	Host                      string
-	ServiceHost               string
-	TLSCertFile               string
-	TLSKeyFile                string
-	MaxConnsPerHost           int
-	ResponseHeaderTimeoutSecs int
-	ReadTimeoutSecs           int
-	WriteTimeoutSecs          int
-	IdleTimeoutSecs           int
+	Host                           string
+	ServiceHost                    string
+	TLSCertFile                    string
+	TLSKeyFile                     string
+	MaxConnsPerHost                int
+	ResponseHeaderTimeoutSecs      int
+	ReadTimeoutSecs                int
+	WriteTimeoutSecs               int
+	IdleTimeoutSecs                int
+	ReverseAddressLookupValidation bool
 }
 
 // AmazonS3Settings is the configuration related to the Amazon S3.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -20,16 +20,16 @@ type Config struct {
 
 // ServiceSettings is the configuration related to the web server.
 type ServiceSettings struct {
-	Host                           string
-	ServiceHost                    string
-	TLSCertFile                    string
-	TLSKeyFile                     string
-	MaxConnsPerHost                int
-	ResponseHeaderTimeoutSecs      int
-	ReadTimeoutSecs                int
-	WriteTimeoutSecs               int
-	IdleTimeoutSecs                int
-	ReverseAddressLookupValidation bool
+	Host                      string
+	ServiceHost               string
+	TLSCertFile               string
+	TLSKeyFile                string
+	MaxConnsPerHost           int
+	ResponseHeaderTimeoutSecs int
+	ReadTimeoutSecs           int
+	WriteTimeoutSecs          int
+	IdleTimeoutSecs           int
+	RequestValidation         bool
 }
 
 // AmazonS3Settings is the configuration related to the Amazon S3.

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -20,16 +20,17 @@ type Config struct {
 
 // ServiceSettings is the configuration related to the web server.
 type ServiceSettings struct {
-	Host                      string
-	ServiceHost               string
-	TLSCertFile               string
-	TLSKeyFile                string
-	MaxConnsPerHost           int
-	ResponseHeaderTimeoutSecs int
-	ReadTimeoutSecs           int
-	WriteTimeoutSecs          int
-	IdleTimeoutSecs           int
-	RequestValidation         bool
+	Host                                string
+	ServiceHost                         string
+	TLSCertFile                         string
+	TLSKeyFile                          string
+	MaxConnsPerHost                     int
+	ResponseHeaderTimeoutSecs           int
+	ReadTimeoutSecs                     int
+	WriteTimeoutSecs                    int
+	IdleTimeoutSecs                     int
+	RequestValidation                   bool
+	RequestValidationExpectedNameSuffix string
 }
 
 // AmazonS3Settings is the configuration related to the Amazon S3.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -166,8 +166,7 @@ func (s *Server) validateRequestMatchesInstallationID(r *http.Request, installat
 	// Example Reverse Lookup:
 	//   IP_ADDR.SERVICE_NAME.NAMESPACE/INSTALLATION_ID.svc.cluster.local.
 	if !s.requestIsValid(name, installationID) {
-		s.logger.Warn("reverse name lookup validation failed", mlog.String("name", name), mlog.String("installationID", installationID))
-		return errors.New("validation failed")
+		return errors.Errorf("reverse name lookup validation failed; name=%s, installationID=%s", name, installationID)
 	}
 
 	s.logger.Debug("reverse name lookup validation passed", mlog.String("name", name), mlog.String("installationID", installationID))

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -6,6 +6,7 @@ package server
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -17,6 +18,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/signer"
+	"github.com/pkg/errors"
 )
 
 func (s *Server) handler() http.HandlerFunc {
@@ -35,8 +37,15 @@ func (s *Server) handler() http.HandlerFunc {
 			s.metrics.observeRequest(r.Method, installationID, statusCode, elapsed)
 		}()
 
-		if s := strings.Split(r.URL.Path, "/"); len(s) > 1 {
-			installationID = s[1]
+		if s := strings.Split(r.URL.Path, "/"); len(s) > 2 {
+			installationID = s[2]
+		}
+
+		if s.cfg.ServiceSettings.ReverseAddressLookupValidation {
+			if err := s.validateRequestMatchesInstallationID(r, installationID); err != nil {
+				s.writeError(w, errors.Wrap(err, "installation ID request validation failed"))
+				return
+			}
 		}
 
 		// Strip the bucket name from the path which gets added by Minio
@@ -140,4 +149,32 @@ func (s *Server) writeError(w http.ResponseWriter, sourceErr error) {
 	if err != nil {
 		s.logger.Warn("failed to write error response", mlog.Err(err))
 	}
+}
+
+func (s *Server) validateRequestMatchesInstallationID(r *http.Request, installationID string) error {
+	addr := strings.Split(r.RemoteAddr, ":")[0]
+	names, err := s.lookupAddrFn(addr)
+	if err != nil {
+		return errors.Wrap(err, "failed to perform reverse domain name lookup")
+	}
+	if len(names) == 0 {
+		return errors.New("no names returned in reverse lookup")
+	}
+	name := names[0]
+
+	// Perform validation by comparing reverse lookup to expected namespace.
+	// Example Reverse Lookup:
+	//   IP_ADDR.SERVICE_NAME.NAMESPACE/INSTALLATION_ID.svc.cluster.local.
+	if !requestIsValid(name, installationID) {
+		s.logger.Warn("reverse name lookup validation failed", mlog.String("name", name), mlog.String("installationID", installationID))
+		return errors.New("validation failed")
+	}
+
+	s.logger.Debug("reverse name lookup validation passed", mlog.String("name", name), mlog.String("installationID", installationID))
+
+	return nil
+}
+
+func requestIsValid(name, installationID string) bool {
+	return strings.HasSuffix(name, fmt.Sprintf(".%s.svc.cluster.local.", installationID))
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -41,7 +41,7 @@ func (s *Server) handler() http.HandlerFunc {
 			installationID = s[2]
 		}
 
-		if s.cfg.ServiceSettings.ReverseAddressLookupValidation {
+		if s.cfg.ServiceSettings.RequestValidation {
 			if err := s.validateRequestMatchesInstallationID(r, installationID); err != nil {
 				s.writeError(w, errors.Wrap(err, "installation ID request validation failed"))
 				return

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -165,7 +165,7 @@ func (s *Server) validateRequestMatchesInstallationID(r *http.Request, installat
 	// Perform validation by comparing reverse lookup to expected namespace.
 	// Example Reverse Lookup:
 	//   IP_ADDR.SERVICE_NAME.NAMESPACE/INSTALLATION_ID.svc.cluster.local.
-	if !requestIsValid(name, installationID) {
+	if !s.requestIsValid(name, installationID) {
 		s.logger.Warn("reverse name lookup validation failed", mlog.String("name", name), mlog.String("installationID", installationID))
 		return errors.New("validation failed")
 	}
@@ -175,6 +175,6 @@ func (s *Server) validateRequestMatchesInstallationID(r *http.Request, installat
 	return nil
 }
 
-func requestIsValid(name, installationID string) bool {
-	return strings.HasSuffix(name, fmt.Sprintf(".%s.svc.cluster.local.", installationID))
+func (s *Server) requestIsValid(name, installationID string) bool {
+	return strings.HasSuffix(name, fmt.Sprintf(".%s.%s", installationID, s.cfg.ServiceSettings.RequestValidationExpectedNameSuffix))
 }

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -253,6 +253,7 @@ func TestHandler(t *testing.T) {
 		}
 
 		cfg.ServiceSettings.RequestValidation = true
+		cfg.ServiceSettings.RequestValidationExpectedNameSuffix = "svc.cluster.local."
 		s := &Server{
 			logger:    mlog.NewTestingLogger(t, os.Stderr),
 			cfg:       cfg,
@@ -319,6 +320,15 @@ func TestWriteError(t *testing.T) {
 }
 
 func TestValidateRequest(t *testing.T) {
+	s := &Server{
+		logger: mlog.NewTestingLogger(t, os.Stderr),
+		cfg: Config{
+			ServiceSettings{RequestValidationExpectedNameSuffix: "svc.cluster.local."},
+			AmazonS3Settings{},
+			LogSettings{},
+		},
+	}
+
 	for _, test := range []struct {
 		description string
 		name        string
@@ -331,7 +341,7 @@ func TestValidateRequest(t *testing.T) {
 		{"valid", "1.1.1.1.mm-test.id1.svc.cluster.local.", "id1", true},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-			assert.Equal(t, test.expected, requestIsValid(test.name, test.id))
+			assert.Equal(t, test.expected, s.requestIsValid(test.name, test.id))
 		})
 	}
 }

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -252,7 +252,7 @@ func TestHandler(t *testing.T) {
 			return strings.TrimPrefix(ts.URL, "http://")
 		}
 
-		cfg.ServiceSettings.ReverseAddressLookupValidation = true
+		cfg.ServiceSettings.RequestValidation = true
 		s := &Server{
 			logger:    mlog.NewTestingLogger(t, os.Stderr),
 			cfg:       cfg,

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -213,6 +213,78 @@ func TestHandler(t *testing.T) {
 		assert.NotEmpty(t, resp.Header.Get("Date"), "empty date")
 		assert.NotEmpty(t, resp.Header.Get("Last-Modified"), "empty last-modified")
 	})
+
+	t.Run("normal response with request validation", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// We test that the bucket name is stripped.
+			assert.Equal(t, "/foo", r.URL.Path)
+
+			now := time.Now()
+
+			// Validate request headers
+			authHeader := r.Header.Get("Authorization")
+			date := r.Header.Get("X-Amz-Date")
+
+			assert.True(t, strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256"), "unexpected prefix for Authorization header: %s", authHeader)
+			assert.True(t, strings.HasPrefix(date, now.Format("20060102")), "unexpected prefix for X-Amz-Date header: %s", date)
+
+			matches := regCred.FindStringSubmatch(authHeader)
+			require.Len(t, matches, 3, "unexpected number of matches")
+			assert.Equal(t, cfg.S3Settings.AccessKeyID, matches[1], "unexpected access key")
+			assert.Equal(t, now.Format("20060102"), matches[2], "unexpected date value")
+
+			matches = regSign.FindStringSubmatch(authHeader)
+			require.Len(t, matches, 2, "unexpected number of matches")
+
+			w.Header().Set("Content-Type", "application/xml")
+			w.Header().Set("Date", now.Format(time.RFC1123))
+			w.Header().Set("Last-Modified", now.Format(time.RFC1123))
+			w.Header().Set("Server", "Asgard")
+			w.Header().Set("X-Amz-Bucket-Region", cfg.S3Settings.Region)
+			w.Header().Set("X-Amz-Id-2", "id")
+			w.Header().Set("X-Amz-Request-Id", "reqId")
+
+			fmt.Fprintln(w, "Welcome to the realm eternal")
+		}))
+		defer ts.Close()
+
+		dummyGetHost := func(bucket, endPoint string) string {
+			return strings.TrimPrefix(ts.URL, "http://")
+		}
+
+		cfg.ServiceSettings.ReverseAddressLookupValidation = true
+		s := &Server{
+			logger:    mlog.NewTestingLogger(t, os.Stderr),
+			cfg:       cfg,
+			getHostFn: dummyGetHost,
+			lookupAddrFn: func(addr string) ([]string, error) {
+				return []string{"1.1.1.1.test.foo.svc.cluster.local."}, nil
+			},
+			client: http.DefaultClient,
+			creds: credentials.NewStatic(cfg.S3Settings.AccessKeyID,
+				cfg.S3Settings.SecretAccessKey, "", credentials.SignatureV4),
+			metrics: newMetrics(),
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com/"+cfg.S3Settings.Bucket+"/foo", nil)
+		w := httptest.NewRecorder()
+
+		s.handler()(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+
+		// Verify response headers
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code")
+		assert.Equal(t, "application/xml", resp.Header.Get("Content-Type"), "unexpected content type")
+		assert.Equal(t, "Asgard", resp.Header.Get("Server"), "unexpected server")
+		assert.Equal(t, cfg.S3Settings.Region, resp.Header.Get("X-Amz-Bucket-Region"), "unexpected region")
+		assert.Equal(t, "id", resp.Header.Get("X-Amz-Id-2"), "unexpected id")
+		assert.Equal(t, "reqId", resp.Header.Get("X-Amz-Request-Id"), "unexpected request id")
+		assert.NotEmpty(t, resp.Header.Get("Date"), "empty date")
+		assert.NotEmpty(t, resp.Header.Get("Last-Modified"), "empty last-modified")
+	})
 }
 
 func TestWriteError(t *testing.T) {
@@ -244,4 +316,22 @@ func TestWriteError(t *testing.T) {
 	expected := `<?xml version="1.0" encoding="UTF-8"?>
 <Error><Code>500</Code><Message>error from valhalla</Message><BucketName>agnivatest</BucketName><Key></Key><Resource></Resource><RequestId></RequestId><HostId></HostId><Region></Region><Server></Server></Error>`
 	assert.Equal(t, expected, string(buf), "unexpected response")
+}
+
+func TestValidateRequest(t *testing.T) {
+	for _, test := range []struct {
+		description string
+		name        string
+		id          string
+		expected    bool
+	}{
+		{"mismatch", "1.1.1.1.mm-test.id1.svc.cluster.local.", "id2", false},
+		{"empty name", "", "id2", false},
+		{"empty id", "1.1.1.1.mm-test.id1.svc.cluster.local.", "", false},
+		{"valid", "1.1.1.1.mm-test.id1.svc.cluster.local.", "id1", true},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expected, requestIsValid(test.name, test.id))
+		})
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,14 +27,15 @@ var (
 
 // Server contains all the necessary information to run Bifrost
 type Server struct {
-	cfg        Config
-	srv        *http.Server
-	serviceSrv *http.Server
-	logger     *mlog.Logger
-	client     *http.Client
-	getHostFn  func(bucket, endPoint string) string
-	creds      *credentials.Credentials
-	metrics    *metrics
+	cfg          Config
+	srv          *http.Server
+	serviceSrv   *http.Server
+	logger       *mlog.Logger
+	client       *http.Client
+	getHostFn    func(bucket, endPoint string) string
+	lookupAddrFn func(addr string) (names []string, err error)
+	creds        *credentials.Credentials
+	metrics      *metrics
 }
 
 // New creates a new Bifrost server
@@ -104,6 +105,7 @@ func New(cfg Config) *Server {
 	}
 
 	s.getHostFn = s.getHost
+	s.lookupAddrFn = net.LookupAddr
 	s.srv.Handler = s.withRecovery(s.handler())
 
 	return s


### PR DESCRIPTION
This change adds optional http request validation logic which can be enabled via the server config. This validation provides an additional layer of security by performing a reverse address lookup and comparing the name against a standard kubernetes namespace check. As we use installation IDs as a direct mapping to Mattermost workspaces, we can require that the ID of the request and request namespace match.

This change also corrects an issue where installation IDs were not being reported correctly for metrics.

Fixes https://mattermost.atlassian.net/browse/CLD-6081
