### PR TITLE
[CLD-8276]Enable bifrost to use IAM role

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -134,10 +134,7 @@ func (s *Server) getHost(bucket, endPoint string) string {
 }
 
 func (s *Server) isUsingIAMRoleCredentials() bool {
-	if s.cfg.S3Settings.AccessKeyID == "" && s.cfg.S3Settings.SecretAccessKey == "" {
-		return true
-	}
-	return false
+	return s.cfg.S3Settings.AccessKeyID == "" && s.cfg.S3Settings.SecretAccessKey == ""
 }
 
 func (s *Server) writeError(w http.ResponseWriter, sourceErr error) {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -95,15 +95,16 @@ func (s *Server) handler() http.HandlerFunc {
 			return
 		}
 
-		// Need to sign the header, just before sending it
-		if s.cfg.S3Settings.AccessKeyID == "" && s.cfg.S3Settings.SecretAccessKey == "" {
-			r = signer.SignV4(*r, val.AccessKeyID, val.SecretAccessKey, val.SessionToken, s.cfg.S3Settings.Region)
-		} else {
-			r = signer.SignV4(*r, s.cfg.S3Settings.AccessKeyID,
-				s.cfg.S3Settings.SecretAccessKey,
-				val.SessionToken,
-				s.cfg.S3Settings.Region)
+		if s.isUsingIAMRoleCredentials() {
+			s.cfg.S3Settings.AccessKeyID = val.AccessKeyID
+			s.cfg.S3Settings.SecretAccessKey = val.SecretAccessKey
 		}
+
+		// Need to sign the header, just before sending it
+		r = signer.SignV4(*r, s.cfg.S3Settings.AccessKeyID,
+			s.cfg.S3Settings.SecretAccessKey,
+			val.SessionToken,
+			s.cfg.S3Settings.Region)
 
 		resp, err := s.client.Do(r)
 		if err != nil {
@@ -130,6 +131,13 @@ func (s *Server) handler() http.HandlerFunc {
 
 func (s *Server) getHost(bucket, endPoint string) string {
 	return bucket + "." + endPoint
+}
+
+func (s *Server) isUsingIAMRoleCredentials() bool {
+	if s.cfg.S3Settings.AccessKeyID == "" && s.cfg.S3Settings.SecretAccessKey == "" {
+		return true
+	}
+	return false
 }
 
 func (s *Server) writeError(w http.ResponseWriter, sourceErr error) {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -96,10 +96,14 @@ func (s *Server) handler() http.HandlerFunc {
 		}
 
 		// Need to sign the header, just before sending it
-		r = signer.SignV4(*r, s.cfg.S3Settings.AccessKeyID,
-			s.cfg.S3Settings.SecretAccessKey,
-			val.SessionToken,
-			s.cfg.S3Settings.Region)
+		if s.cfg.S3Settings.AccessKeyID == "" && s.cfg.S3Settings.SecretAccessKey == "" {
+			r = signer.SignV4(*r, val.AccessKeyID, val.SecretAccessKey, val.SessionToken, s.cfg.S3Settings.Region)
+		} else {
+			r = signer.SignV4(*r, s.cfg.S3Settings.AccessKeyID,
+				s.cfg.S3Settings.SecretAccessKey,
+				val.SessionToken,
+				s.cfg.S3Settings.Region)
+		}
 
 		resp, err := s.client.Do(r)
 		if err != nil {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -27,6 +27,101 @@ var regCred = regexp.MustCompile("Credential=([A-Za-z0-9]+)/([0-9]+)/")
 // regCred matches signature string in HTTP header
 var regSign = regexp.MustCompile("Signature=([[0-9a-f]+)")
 
+type MockIAMCredentialsProvider struct{}
+
+func (m *MockIAMCredentialsProvider) Retrieve() (credentials.Value, error) {
+	return credentials.Value{
+		AccessKeyID:     "mockedAccessKeyID",
+		SecretAccessKey: "mockedSecret",
+	}, nil
+}
+
+func (m *MockIAMCredentialsProvider) IsExpired() bool {
+	return false // Assume the mocked credentials are never expired
+}
+
+func TestHandlerUsingIAMRole(t *testing.T) {
+	cfg := Config{
+		S3Settings: AmazonS3Settings{
+			Region:   "us-east-1",
+			Endpoint: "s3.dualstack.us-east-1.amazonaws.com",
+			Scheme:   "http",
+			Bucket:   "agnivatest",
+		},
+	}
+
+	t.Run("normal response", func(t *testing.T) {
+		creds := credentials.New(&MockIAMCredentialsProvider{})
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// We test that the bucket name is stripped.
+			assert.Equal(t, "/foo", r.URL.Path)
+
+			now := time.Now()
+
+			// Get the credentials
+			val, _ := creds.Get()
+
+			// Validate request headers
+			authHeader := r.Header.Get("Authorization")
+			date := r.Header.Get("X-Amz-Date")
+
+			assert.True(t, strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256"), "unexpected prefix for Authorization header: %s", authHeader)
+			assert.True(t, strings.HasPrefix(date, now.Format("20060102")), "unexpected prefix for X-Amz-Date header: %s", date)
+
+			matches := regCred.FindStringSubmatch(authHeader)
+			require.Len(t, matches, 3, "unexpected number of matches")
+			assert.Equal(t, val.AccessKeyID, matches[1], "unexpected access key")
+			assert.Equal(t, now.Format("20060102"), matches[2], "unexpected date value")
+
+			matches = regSign.FindStringSubmatch(authHeader)
+			require.Len(t, matches, 2, "unexpected number of matches")
+
+			w.Header().Set("Content-Type", "application/xml")
+			w.Header().Set("Date", now.Format(time.RFC1123))
+			w.Header().Set("Last-Modified", now.Format(time.RFC1123))
+			w.Header().Set("Server", "Asgard")
+			w.Header().Set("X-Amz-Bucket-Region", cfg.S3Settings.Region)
+			w.Header().Set("X-Amz-Id-2", "id")
+			w.Header().Set("X-Amz-Request-Id", "reqId")
+
+			fmt.Fprintln(w, "Welcome to the realm eternal")
+		}))
+		defer ts.Close()
+
+		dummyGetHost := func(_, _ string) string {
+			return strings.TrimPrefix(ts.URL, "http://")
+		}
+
+		s := &Server{
+			logger:    mlog.NewTestingLogger(t, os.Stderr),
+			cfg:       cfg,
+			getHostFn: dummyGetHost,
+			client:    http.DefaultClient,
+			creds:     creds,
+			metrics:   newMetrics(),
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com/"+cfg.S3Settings.Bucket+"/foo", nil)
+		w := httptest.NewRecorder()
+
+		s.handler()(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+
+		// Verify response headers
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code")
+		assert.Equal(t, "application/xml", resp.Header.Get("Content-Type"), "unexpected content type")
+		assert.Equal(t, "Asgard", resp.Header.Get("Server"), "unexpected server")
+		assert.Equal(t, cfg.S3Settings.Region, resp.Header.Get("X-Amz-Bucket-Region"), "unexpected region")
+		assert.Equal(t, "id", resp.Header.Get("X-Amz-Id-2"), "unexpected id")
+		assert.Equal(t, "reqId", resp.Header.Get("X-Amz-Request-Id"), "unexpected request id")
+		assert.NotEmpty(t, resp.Header.Get("Date"), "empty date")
+		assert.NotEmpty(t, resp.Header.Get("Last-Modified"), "empty last-modified")
+	})
+}
+
 func TestHandler(t *testing.T) {
 	cfg := Config{
 		S3Settings: AmazonS3Settings{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,6 +74,13 @@ func New(cfg Config) *Server {
 		},
 	}
 
+	var creds *credentials.Credentials
+	if cfg.S3Settings.AccessKeyID == "" && cfg.S3Settings.SecretAccessKey == "" {
+		creds = credentials.NewIAM("")
+	} else {
+		creds = credentials.NewStatic(cfg.S3Settings.AccessKeyID, cfg.S3Settings.SecretAccessKey, "", credentials.SignatureV4)
+	}
+
 	s := &Server{
 		srv:    server,
 		client: client,
@@ -87,7 +94,7 @@ func New(cfg Config) *Server {
 			FileLocation:  cfg.LogSettings.FileLocation,
 		}),
 		cfg:     cfg,
-		creds:   credentials.NewStatic(cfg.S3Settings.AccessKeyID, cfg.S3Settings.SecretAccessKey, "", credentials.SignatureV4),
+		creds:   creds,
 		metrics: newMetrics(),
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR will enable Bifrost to use the IAM role as credentials to access the S3 bucket. This will allow us to use IRSA when deployed in EKS clusters.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/CLD-8276